### PR TITLE
Bug fix: Trailing spaces and special characters in folder name 🚀

### DIFF
--- a/functions/utils/helpers.ts
+++ b/functions/utils/helpers.ts
@@ -8,7 +8,7 @@ function extractKeyAndBucket(
   const { uri, origin } = data;
 
   const bucket = origin?.s3?.domainName.split(".")[0];
-  let key = uri.substring(1);
+  let key = uri.replace(/^\/\+/, " ").replace(/^\//, "");
 
   if (enableSyntacticSugar) {
     const { format, keyName } = getPossibleExtensionFromKey(key);

--- a/functions/utils/helpers.ts
+++ b/functions/utils/helpers.ts
@@ -10,6 +10,9 @@ function extractKeyAndBucket(
   const bucket = origin?.s3?.domainName.split(".")[0];
   let key = uri.replace(/^\/\+/, " ").replace(/^\//, "");
 
+  // decode uri key
+  key = decodeURIComponent(key);
+
   if (enableSyntacticSugar) {
     const { format, keyName } = getPossibleExtensionFromKey(key);
 


### PR DESCRIPTION
# Description

Fixes an edge case where there is a space on front of the folder name of s3 and also fixes folder names having special characters

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested it locally with the below testcases.

1. / /NdUMSs9EjBLN.jpeg, /+/NdUMSs9EjBLN.jpeg
2. / +spaceplus/x.webp, /++spaceplus/x.webp
3. / 918298863434/intro_images/first.jpg, /+918298863434/intro_images/first.jpg
4. / spacedfolder/NdUMSs9EjBLN.jpeg, /+spacedfolder/NdUMSs9EjBLN.jpeg
5. /+/x.webp (/%2B/x.webp)
6. /+plus/x.webp (/%2Bplus/x.webp)
7. /optimisation/NdUMSs9EjBLN.jpeg

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Changes

- N/A

## Flags

- N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
